### PR TITLE
Get prod deploys working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,11 @@ workflows:
       - deploy-staging:
           requires:
             - staging-deploy-ask
+          filters:
+            branches:
+              ignore:
+                - master
       - deploy-prod:
-          requires:
-            - deploy-staging
           filters:
             branches:
               only: master


### PR DESCRIPTION
Remove requirement of staging deploy since it will happen on all non-master branches before merge into master. Hoping that taking out the requirements of deploy to staging in master branch, will allow the deploy to prod to actually be triggered.