### PR TITLE
change geography for onica customers

### DIFF
--- a/utils/signup.js
+++ b/utils/signup.js
@@ -15,6 +15,7 @@ export const formatAltCustomer = (type) => {
 
 export const formatRequest = (values) => {
   const type = _.get(values, ['customerInfo', 'customerType']);
+  const billingCountry = _.get(values, ['billingInfo', 'address', 'country']);
   const template = (
     type !== 'rackspace'
       ? formatAltCustomer(type.toUpperCase())
@@ -24,6 +25,7 @@ export const formatRequest = (values) => {
     ...template,
     accountName: values.userInfo.accountName,
     externalId: (values.customerInfo.productType).toUpperCase(),
+    geography: billingCountry !== 'US' && type === 'onica' ? 'UK' : 'US',
     serviceLevel: 'MANAGED',
     currencyCode: values.billingInfo.currency.toUpperCase(),
     description: `A Karate (${type.toUpperCase()}) cloud signup request from the retail site.`,

--- a/utils/signup.test.js
+++ b/utils/signup.test.js
@@ -74,6 +74,42 @@ describe('utils/signup', () => {
         expect(phoneNumber.number).toEqual(defaultValues.userInfo.phoneNumber.number);
       });
     });
+    test('geography changes if type is onica and country is not US', () => {
+      const props = {
+        customerInfo: {
+          customerType: 'onica',
+          productType: 'product'
+        },
+        billingInfo: {
+          currency: 'CAD',
+          address: {
+            country: 'CA'
+          }
+        }
+      };
+      const result = formatRequest(props);
+      expect(result.geography).toEqual('UK');
+    });
+    ['rackspace', 'rbu'].forEach((customerType) => {
+      ['other', 'US'].forEach((country) => {
+        test(`returns US geography for ${customerType} when country is ${country}`, () => {
+          const props = {
+            customerInfo: {
+              productType: 'product',
+              customerType
+            },
+            billingInfo: {
+              currency: 'US',
+              address: {
+                country
+              }
+            }
+          };
+          const result = formatRequest(props);
+          expect(result.geography).toEqual('US');
+        });
+      });
+    });
   });
 
   describe('formatAltCustomer', () => {


### PR DESCRIPTION
Related to this ticket: https://jira.rax.io/browse/APOLLO-1665

Geography changes to UK in the req body for Onica customers residing outside of the US. 