### PR TITLE
fixed password and username error fields

### DIFF
--- a/app/components/SignUp/UserDetails/UserName.js
+++ b/app/components/SignUp/UserDetails/UserName.js
@@ -27,7 +27,7 @@ export class UserName extends React.Component {
   };
 
   render() {
-    const { t, syncErrors: { userInfo }, username } = this.props;
+    const { t, syncErrors: { userInfo }, username, exists } = this.props;
     const tooltip = (
       <Tooltip id="username">{t('account:user.tips.username.generate')}</Tooltip>
     );
@@ -40,6 +40,7 @@ export class UserName extends React.Component {
           tooltip={tooltip}
           type="text"
           label={t('account:user.actions.username.create')}
+          hxClassNames={exists ? 'hxInvalid' : ''}
           required
         >
           {suffix && <span className="hxSuffix">{suffix}</span>}

--- a/app/components/SignUp/UserDetails/UserName.test.js
+++ b/app/components/SignUp/UserDetails/UserName.test.js
@@ -14,6 +14,7 @@ describe('UserName', () => {
     error: false,
     loading: false,
     success: false,
+    hxClassNames: '',
     setUsername: setUsernameMock,
     syncErrors: {
       userInfo: {
@@ -69,13 +70,5 @@ describe('UserName', () => {
     };
     const wrapper = shallow(<UserName {...defaultProps} {...props} />);
     expect(wrapper.find('hx-icon[class="checkmark"]').length).toBeTruthy();
-  });
-
-  test('it does not render a suffix if the username does not exist', () => {
-    const props = {
-      username: ''
-    };
-    const wrapper = shallow(<UserName {...defaultProps} {...props} />);
-    expect(wrapper.find('hx-icon').length).toBeFalsy();
   });
 });

--- a/app/components/SignUp/UserDetails/UserName.test.js
+++ b/app/components/SignUp/UserDetails/UserName.test.js
@@ -71,4 +71,12 @@ describe('UserName', () => {
     const wrapper = shallow(<UserName {...defaultProps} {...props} />);
     expect(wrapper.find('hx-icon[class="checkmark"]').length).toBeTruthy();
   });
+
+  test('it does not render a suffix if the username does not exist', () => {
+    const props = {
+      username: ''
+    };
+    const wrapper = shallow(<UserName {...defaultProps} {...props} />);
+    expect(wrapper.find('hx-icon').length).toBeFalsy();
+  });
 });

--- a/app/validators/index.js
+++ b/app/validators/index.js
@@ -282,14 +282,14 @@ export const validateUser = (values, { t = i18nT() }) => {
   };
 };
 
-export const asyncValidate = (values, dispatch, { t = i18nT(), asyncErrors }, field) => {
+export const asyncValidate = (values, dispatch, { t = i18nT(), asyncErrors = {} }, field) => {
   const { userInfo: { username, password } } = values;
   if (field === 'userInfo.username') {
     return asyncValidateUsername(username, dispatch, t).catch((error) => {
-      throw !asyncErrors ? error : _.merge(asyncErrors, error); // asyncErrors is undefined if none exist
+      throw _.merge(asyncErrors, error); // asyncErrors is undefined if none exist
     });
   }
   return asyncValidatePassword(password, t).catch((error) => {
-    throw !asyncErrors ? error : _.merge(asyncErrors, error);
+    throw _.merge(asyncErrors, error);
   });
 };

--- a/app/validators/index.js
+++ b/app/validators/index.js
@@ -1,7 +1,7 @@
 import i18n from '../i18n';
 import _ from 'lodash';
 import validate from 'validate.js';
-import { asyncValidateUsername, asyncValidatePassword } from './utils';
+import { asyncValidatePassword, asyncValidateUsername } from './utils';
 
 function translateDefaultValidators(t) {
   validate.validators.presence.message = t('validation:input.required');
@@ -198,7 +198,10 @@ export const validateBilling = (values, { t = i18nT(), ...props }) => {
   const billing = _.get(values, 'billingInfo', {});
   return {
     billingInfo: {
-      ...validateAddress(billing, { t, props }),
+      ...validateAddress(billing, {
+        t,
+        props
+      }),
       ...validateCurrency(billing, t),
       ...validateContractEntity(billing, t)
     }
@@ -279,8 +282,14 @@ export const validateUser = (values, { t = i18nT() }) => {
   };
 };
 
-export const asyncValidate = (values, dispatch, { t = i18nT() }, field) => {
+export const asyncValidate = (values, dispatch, { t = i18nT(), asyncErrors }, field) => {
   const { userInfo: { username, password } } = values;
-  return field === 'userInfo.username'
-    ? asyncValidateUsername(username, dispatch, t) : asyncValidatePassword(password, t);
+  if (field === 'userInfo.username') {
+    return asyncValidateUsername(username, dispatch, t).catch((error) => {
+      throw !asyncErrors ? error : _.merge(asyncErrors, error); // asyncErrors is undefined if none exist
+    });
+  }
+  return asyncValidatePassword(password, t).catch((error) => {
+    throw !asyncErrors ? error : _.merge(asyncErrors, error);
+  });
 };

--- a/test/provider.js
+++ b/test/provider.js
@@ -1,4 +1,4 @@
-import * as enzyme from 'enzyme';
+import enzyme from 'enzyme';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
@@ -10,7 +10,7 @@ import rootReducer from '../app/reducers/rootReducer';
 import thunk from 'redux-thunk';
 
 
-function withForm(Component, { props = {}, defaultProps, method, withRouter = false }) {
+function withForm(Component, { props = {}, defaultProps = {}, method, withRouter = false }) {
   const FormWrapper = reduxForm({ form: 'testForm' })(Component);
   const store = createStore(rootReducer, applyMiddleware(thunk));
   const history = createMemoryHistory();
@@ -47,12 +47,12 @@ export function mountedForm(Component, options) {
  * See AddressSection.test.js for reference
  * */
 export function mountWithForm(Component, options) {
-  return mountedForm(Component, options).find(Component);
+  return mountedForm(Component, options);
 }
 
 export function shallowWithForm(Component, options) {
   return withForm(Component, {
-    ...options,
+    options,
     method: 'shallow'
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,11 +1429,6 @@
   resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz#384f4f6d54563ba465fb4df21fe89e78a76fc530"
   integrity sha512-cV4+sAmshf8ysU2USutrSRYQkJzEYKHsRCGa0CkMElGpG5747VHtkfsW3NdVIBV/m2MDKXTDydT4lkrysH7IFA==
 
-"@webcomponents/webcomponentsjs@^2.4.3":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz#14b7e78da47f8f0071ff96c35335b871534179bc"
-  integrity sha512-UWXZYbaDLLfhm+xONXTiDciyhOSwKRrZieGQHFMSMGSxY4mbjZ5uYzOKgnuX0luYFvjJw32G3r0sCwQZPJIR4Q==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
- Error shows if both async fields fail
- Username Field now has red outline on error to match other fields
- Changed tests for asyncValidation to use `async/await`
- Added tests for asyncValidation

**Before:**
![Before](https://user-images.githubusercontent.com/17368376/92971791-1af3cb00-f44f-11ea-851d-315e6ba93633.gif)

**After:**
![After](https://user-images.githubusercontent.com/17368376/92971818-2941e700-f44f-11ea-9a83-6d7f022a4d2c.gif)
